### PR TITLE
fix: remove "imperative assignment" that breaks on Elixir >= 1.7

### DIFF
--- a/lib/linguist/vocabulary.ex
+++ b/lib/linguist/vocabulary.ex
@@ -66,13 +66,15 @@ defmodule Linguist.Vocabulary do
   """
   defmacro locale(name, source) do
     quote bind_quoted: [name: name, source: source] do
-      if is_binary(source) do
-        @external_resource source
-        source = Code.eval_file(source) |> elem(0)
-      end
+      source =
+        if is_binary(source) do
+          @external_resource source
+          Code.eval_file(source) |> elem(0)
+        else
+          source
+        end
+
       @locales {name, source}
     end
   end
-
 end
-


### PR DESCRIPTION
This pull request enable `mix test` to pass under Elixir versions 1.6.6 to 1.10.0.

Please refer to https://github.com/elixir-lang/elixir/issues/8076#issuecomment-412526405 for more on the breaking change introduced by Elixir 1.7.